### PR TITLE
Fix insertText method

### DIFF
--- a/lit-ace.js
+++ b/lit-ace.js
@@ -698,7 +698,7 @@ class LitAce extends LitElement {
   insertText(row, column, text) {
     let positionObject = { row, column };
     this.editor.session.insert(positionObject, text);
-    editorBlurChangeAction();
+    this.editorBlurChangeAction();
   }
 
   calculateCursorPositionFromIndex(index) {
@@ -876,12 +876,12 @@ class LitAce extends LitElement {
 <html>
   <head>
   <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet"> 
+  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap" rel="stylesheet">
     <style>
       #aceRaw {
         font-family: 'Source Code Pro', monospace;
         font-size: 12px;
-      }     
+      }
     </style>
   </head>
   <body>
@@ -911,7 +911,7 @@ class LitAce extends LitElement {
 <html>
   <head>
     <style>
-      ${result.css} 
+      ${result.css}
     </style>
   </head>
     <body>


### PR DESCRIPTION
There is an issue when I use insertText:

> Uncaught ReferenceError: editorBlurChangeAction is not defined/n  insertText lit-ace.js:700

Because `this` is missing.

This PR fixes the issue.